### PR TITLE
deps: bump com.android.application from 8.5.2 to 8.7.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "8.7.2"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
Bumps com.android.application from 8.5.2 to 8.7.2.

---
updated-dependencies:
- dependency-name: com.android.application dependency-type: direct:production update-type: version-update:semver-minor ...