### PR TITLE
deps: bump androidx.activity:activity-compose from 1.9.1 to 1.9.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.4"
-activityCompose = "1.9.1"
+activityCompose = "1.9.3"
 composeBom = "2024.08.00"
 
 [libraries]


### PR DESCRIPTION
Bumps androidx.activity:activity-compose from 1.9.1 to 1.9.3.

---
updated-dependencies:
- dependency-name: androidx.activity:activity-compose dependency-type: direct:production update-type: version-update:semver-patch ...